### PR TITLE
Update XMLUtil.java

### DIFF
--- a/src/cl/nic/dte/util/XMLUtil.java
+++ b/src/cl/nic/dte/util/XMLUtil.java
@@ -589,7 +589,7 @@ public class XMLUtil {
 			
 			xml.save(out, opts);
 
-			return out.toString("ISO-8859-1").replaceAll("\n", "").getBytes("ISO-8859-1");
+			return out.toString("ISO-8859-1").replaceAll("\n", "").replaceAll("\r", "").getBytes("ISO-8859-1");
 			// return out.toString("ISO-8859-1").getBytes("ISO-8859-1");
 		} catch (UnsupportedEncodingException e) {
 			// Nunca debe invocarse


### PR DESCRIPTION
En la línea 592, se obliga a quitar los retornos de carro ("\r"), ya que al correr el proyecto bajo sistemas Windows, el timbrado de los DTE tiende a fallar.
